### PR TITLE
test: fix findOneAndUpdate to return new data

### DIFF
--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -45,7 +45,7 @@ describe('examples', function() {
       then(() => Promise.all([
         Model.find().lean(),
         Model.findOne().lean(),
-        Model.findOneAndUpdate({}, { name: 'test', objects: [{ name: 'test2' }, { name: 'test3' }] }).lean()
+        Model.findOneAndUpdate({}, { name: 'test', objects: [{ name: 'test2' }, { name: 'test3' }] }, { new: true }).lean()
       ])).
       then(results => {
         Model.deleteMany();const [findRes, findOneRes, findOneAndUpdateRes] = results;


### PR DESCRIPTION
mongoose breaking changes in v4: findOneAndUpdate will return old data by default
https://github.com/Automattic/mongoose/commit/8b31481ce665141b47d689b71fc10565b056c43b